### PR TITLE
resolve: 선, 사각형, 삼각형, 원의 크기가 0일 때 undefined 참조 에러 해결

### DIFF
--- a/src/components/Canvas/index.jsx
+++ b/src/components/Canvas/index.jsx
@@ -186,6 +186,7 @@ const Canvas = ({ settings }) => {
   };
 
   const drawLine = (path, ctx) => {
+    if (path.length < 2) return;
     ctx.beginPath();
     ctx.moveTo(path[0][0], path[0][1]);
     ctx.lineTo(path[1][0], path[1][1]);
@@ -199,6 +200,7 @@ const Canvas = ({ settings }) => {
   };
 
   const drawRect = (path, ctx) => {
+    if (path.length < 2) return;
     ctx.beginPath();
     ctx.rect(
       path[0][0],
@@ -216,6 +218,7 @@ const Canvas = ({ settings }) => {
   };
 
   const drawTri = (path, ctx) => {
+    if (path.length < 2) return;
     ctx.beginPath();
     ctx.moveTo(path[0][0], path[0][1]);
     ctx.lineTo(path[0][0] * 2 - path[1][0], path[1][1]);
@@ -236,6 +239,7 @@ const Canvas = ({ settings }) => {
   };
 
   const drawCircle = (path, ctx) => {
+    if (path.length < 2) return;
     ctx.beginPath();
     ctx.arc(path[0][0], path[0][1], getDistance(path), 0, 2 * Math.PI);
     ctx.stroke();


### PR DESCRIPTION
drawCircle, Rect, Line, Triangle 할 때에도 
    if (path.length < 2) return;
이게 필요합니당
없으면 아무 위치에서나 두 번 클릭하면 path.length = 1이 되어서 draw함수에서 undefined의 속성을 참조하게 되어요